### PR TITLE
Removed MS LaTeX package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "donjayamanne.python",
         "DougFinke.vscode-pandoc",
         "James-Yu.latex-workshop",
-        "MattiasPernhult.vscode-todo",
-        "ms-vscode.latex"
+        "MattiasPernhult.vscode-todo"
     ]
 }


### PR DESCRIPTION
This package has been deprecated and they suggest moving to latex workshop which is already in the pack.