### PR TITLE
Removing deprecated extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     ],
     "extensionDependencies": [
         "donjayamanne.git-extension-pack",
-        "donjayamanne.jupyter",
         "donjayamanne.python",
         "DougFinke.vscode-pandoc",
         "James-Yu.latex-workshop",


### PR DESCRIPTION
The Jupyter extension content is now in the already included `donjayamanne.python` extension, removing this will remove deprecation warnings! 💖 